### PR TITLE
Changing Metadata/Text Proposal for About Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html>
   <head>
-    <title> 3d.io modifiers for 3d models and 3d.io furniture</title>
+    <title>3d.io Modifications</title>
     <meta name="charset" content="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="keywords" content="3d, aframe, webgl, webvr, archilogic, 3d.io, interior, 3d furniture, 3d modifier, 3d style, origami">
-    <meta name="description" content="xxx">
+    <meta name="description" content="Application to modify 3d models and 3d.io furniture">
   
     <link href="https://fonts.googleapis.com/css?family=Fira+Sans:200,400,700" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css">
@@ -21,7 +21,7 @@
     <section id="overview-panel">
       <!-- left view -->
       <div id="title">
-        <h3>3d.io</h3>
+        <img src="https://3d.io/img/logo/3d-io-logo-large.svg" alt="3d.io toolkit for interior apps" style="width: 100%; max-width: 250px; margin: 15px 0;" href="https://3d.io" target="_blank">
         <h1>modify 3d data</h1>
       </div>
       <div id="settings">
@@ -33,7 +33,8 @@
       </div>
       <div id="about">
         <h2>About</h2>
-        <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. </p>
+        <p>The application <i>3d.io Modifications</i> enables you to transform your 3D content very easily using scalable preprocessing in the cloud. It allows the representation of your <a href="https://spaces.archilogic.com/explore?popup=order">3d models</a> or your <a href="https://furniture.3d.io">3d furniture</a> in different 3d styles. Thus making your 3d content unique and fun.<br/> To take advantage of this app, all you have to do is choose a 3d setting then insert your 3d content, either via a furniture ID (see <a href="https://furniture.3d.io">furniture.3d.io</a> for more IDs) or via your <a href="https://aframe.io/">A Frame</a> code and let the magic happens.<br/> 
+          To integrate this technology into your own Webgl, Webvr, three.js or Aframe code, we made it accessible via API. Please consult our <a href="">documentation</a> to learn more.<br/>This application is a service from <a href="https://3d.io">3d.io</a> and is subject to usage limitation. To learn more about our quotas, please consult <a href="https://3d.io/#pricing">here</a>.</p>
       </div>
     </section>
     <section id="input-panel">


### PR DESCRIPTION
Scope: Changing Metadata / Text Proposal for the about section

Design/ Specific Changes: 
- title was too long to fit a tab 
- added description (before "xxx")
- replaced "h3>3d.io</h3>" with 3d.io logo (and link to 3d.io) => I did not see how it looks like so please resize if necessary.
- change about section

Notes: there are a lot of links and keywords in the new text for the about section. This is particularly important for SEO.